### PR TITLE
Replace include with readfile

### DIFF
--- a/www/artists/acrease/index.php
+++ b/www/artists/acrease/index.php
@@ -6,10 +6,10 @@
         </title>
     </head>
     <body>
-        <?php include("title.html"); ?>
+        <?php readfile("title.html"); ?>
         <br/>
-        <?php include("homepage.html"); ?>
-        <?php include("galpage.html"); ?>
-        <?php include("conpage.html"); ?>
+        <?php readfile("homepage.html"); ?>
+        <?php readfile("galpage.html"); ?>
+        <?php readfile("conpage.html"); ?>
     </body>
 </html>


### PR DESCRIPTION
Include should only be used on PHP files. All the files in acrease being 
included are html files. They should strictly be read, not included. 
(Also, sorry about the branch name. I made it while under the impression 450 was a code issue, rather than a server side issue, and thus could be solved on a branch.)